### PR TITLE
CSS fix for erroneous page horizontal scrolling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -5,6 +5,7 @@
 
 html {
   background-color: #F2F2F2;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Nella homepage la pagina scrolla orizzontalmente quando non dovrebbe ([screenshot per referenza](http://cl.ly/image/092S041v1X2m/Image%202014-03-05%20at%2010.41.58%20AM.png)).

Questa regoletta fixa il comportamento errato.
